### PR TITLE
Added ability to move landmarks without resetting visitors

### DIFF
--- a/src/main/java/net/oldschoolminecraft/lmk/LmkManager.java
+++ b/src/main/java/net/oldschoolminecraft/lmk/LmkManager.java
@@ -105,6 +105,19 @@ public class LmkManager
         save();
     }
 
+    public void moveCurrentLandmark(String name, Player player) throws NotFoundException
+    {
+        if (findLandmark(name) == null) throw new NotFoundException();
+        LandmarkData newLmkLoc = findLandmark(name);
+        newLmkLoc.worldName = player.getWorld().getName();
+        newLmkLoc.x = player.getLocation().getX();
+        newLmkLoc.y = player.getLocation().getY();
+        newLmkLoc.z = player.getLocation().getZ();
+        newLmkLoc.yaw = player.getLocation().getYaw();
+        newLmkLoc.pitch = player.getLocation().getPitch();
+        save();
+    }
+
     public ArrayList<LandmarkData> getLandmarks()
     {
         return landmarks;

--- a/src/main/java/net/oldschoolminecraft/lmk/cmd/Admin.java
+++ b/src/main/java/net/oldschoolminecraft/lmk/cmd/Admin.java
@@ -80,6 +80,22 @@ public class Admin implements CommandExecutor
                     return true;
                 }
                 break;
+            case "move":
+                if (!(sender instanceof Player))
+                {
+                    sender.sendMessage(ChatColor.RED + "Only players can move landmarks!");
+                    return true;
+                }
+
+                try
+                {
+                    plugin.getLmkManager().moveCurrentLandmark(name, ply);
+                    sender.sendMessage(ChatColor.GREEN + "Successfully moved landmark '" + name + "'!");
+                } catch (NotFoundException e) {
+                    sender.sendMessage(ChatColor.RED + "No landmark called '" + ChatColor.DARK_GRAY + name + ChatColor.RED + "' found!");
+                    return true;
+                }
+                break;
         }
 
         return true;

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -12,7 +12,7 @@ commands:
     permission: landmarks.listandtp
   lmkadmin:
     description: Manage landmarks
-    usage: /<command> <create/delete> <name>
+    usage: /<command> <create/delete/move> <name>
     default: op
     permission: landmarks.admin
   lmksort:


### PR DESCRIPTION
/lmkadmin move <lmk name> - Landmark **must** be an existing landmark for it to be able to be moved.